### PR TITLE
🐛 Fixing wrong install command

### DIFF
--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -12,7 +12,7 @@ You can easily add this project to your own by using your favorite project manag
 <Tabs>
 	<TabItem label="pip">
 		```bash
-		foo@bar:~$ pip install bookshelf
+		foo@bar:~$ pip install bookshelf-cli
 		```
 	</TabItem>
 </Tabs>


### PR DESCRIPTION
Fixed the issue with bookshelf install command being wrong. It is now right